### PR TITLE
video: create persistent internal user

### DIFF
--- a/team-video/templates/deploy_prosody.yaml
+++ b/team-video/templates/deploy_prosody.yaml
@@ -29,7 +29,15 @@ spec:
          lifecycle:
            postStart:
              exec:
-               command: ["/bin/bash", "-c", "sleep 60; prosodyctl --config /config/prosody.cfg.lua register {{ .Values.auth.admin.user }} {{ .Values.app.name }}.{{ .Values.app.domain }} {{ .Values.auth.admin.password }}"]
+               command:
+                 - "/bin/bash"
+                 - "-c"
+                 - |-
+                   sleep 60
+                   {{- $app := .Values.app }}
+                   {{- range .Values.auth.users }}
+                   prosodyctl --config /config/prosody.cfg.lua register {{ .name }} {{ $app.name }}.{{ $app.domain }} {{ .password }}
+                   {{- end }}
          {{end}}
          image: jitsi/prosody
          imagePullPolicy: {{ .Values.app.pullpolicy }}

--- a/team-video/values.yaml
+++ b/team-video/values.yaml
@@ -7,9 +7,9 @@ auth:
   enabled: false
   guests: true
   type: "internal"
-  admin:
-    user: admin
-    password: "jitsiAdmin"
+  users:
+    - name: admin
+      password: "jitsiAdmin"
 
 logLevel: "info"
 hideWelcomePage: true

--- a/values-video.yaml
+++ b/values-video.yaml
@@ -8,9 +8,9 @@ auth:
   guests: true
   # internal auth
   type: internal
-  admin:
-    user: admin
-    password: "jitsiAdmin"
+  users:
+    - user: admin
+      password: "jitsiAdmin"
   # ldap auth - remove above "type: internal" auth to use it
   #type: ldap
   #ldapauthmethod: bind

--- a/values-video.yaml
+++ b/values-video.yaml
@@ -9,7 +9,7 @@ auth:
   # internal auth
   type: internal
   users:
-    - user: admin
+    - name: admin
       password: "jitsiAdmin"
   # ldap auth - remove above "type: internal" auth to use it
   #type: ldap


### PR DESCRIPTION
Fixes #25.

To continue to not use persistent memory create the internal users like the former *admin* at the start. Since there is no dedicated *admin* rename the configuration to *users*.