### PR TITLE
Update Optionen, no-deploy wurde abgelöst

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 # Install and run K3S
-curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--no-deploy traefik --write-kubeconfig-mode 644" sh -
+curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--disable traefik --write-kubeconfig-mode 644" sh -
 
 # Install helm
 curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash


### PR DESCRIPTION
https://rancher.com/docs/k3s/latest/en/installation/install-options/server-config/#deprecated-options