### PR TITLE
[team-video] fix prosody deployment with auth disabled

### DIFF
--- a/team-video/templates/deploy_prosody.yaml
+++ b/team-video/templates/deploy_prosody.yaml
@@ -25,7 +25,7 @@ spec:
           - containerPort: 5347
          resources: {}
 #         restartPolicy: Always
-         {{ if eq .Values.auth.type "internal" }}
+         {{ if and .Values.auth.enabled (eq .Values.auth.type "internal") }}
          lifecycle:
            postStart:
              exec:


### PR DESCRIPTION
when auth is disabled, the default deployment will never get healthy because the prosody container is killed due to failing registration of the admin user. The lifecycle script should only run if auth is actually enabled.

This fixes the "make everything public" use-case. It will fail with the following error:

```
pod/meet-team-video-prosody-665c896c84-kwggd   0/1     PostStartHookError: command '/bin/bash -c sleep 60; prosodyctl --config /config/prosody.cfg.lua register admin video.example.org jitsiAdmin' exited with 1:    0          2m3s
```

The error message in the logs is: `message: "Error: Account creation/modification not supported.\n"`

This changes makes sure everything works as expected.