### PR TITLE
added port settings for outward facing ports

### DIFF
--- a/team-setup/templates/ingress/02-service.yaml
+++ b/team-setup/templates/ingress/02-service.yaml
@@ -7,12 +7,12 @@ spec:
   ports:
     - protocol: TCP
       name: web
-      port: 80
-      targetPort: 80
+      port: {{ .Values.ports.web }}
+      targetPort: {{ .Values.ports.web }}
     - protocol: TCP
       name: websecure
-      port: 443
-      targetPort: 443
+      port: {{ .Values.ports.websecure }}
+      targetPort: {{ .Values.ports.websecure }}
   selector:
     app: traefik
   type: LoadBalancer

--- a/team-setup/templates/ingress/04-deployment.yml
+++ b/team-setup/templates/ingress/04-deployment.yml
@@ -30,8 +30,8 @@ spec:
           args:
             - --api.insecure
             - --accesslog
-            - --entrypoints.web.Address=:80
-            - --entrypoints.websecure.Address=:443
+            - --entrypoints.web.Address=:{{ .Values.ports.web }}
+            - --entrypoints.websecure.Address=:{{ .Values.ports.websecure }}
             - --providers.kubernetescrd
             - --certificatesresolvers.default.acme.tlschallenge
             - --certificatesresolvers.default.acme.email={{ .Values.acme.mail }}

--- a/values-setup.yaml
+++ b/values-setup.yaml
@@ -5,3 +5,7 @@ acme:
 app:
   name: cloud
   domain: example.org
+
+ports:
+  web: 80
+  websecure: 443


### PR DESCRIPTION
I added port settings for the outward facing ports. This allows users to specify the outward facing ports in one central place in case the ports 80 and 443 are already in use on the host machine (e.g. on a server running [OpenMediaVault](https://www.openmediavault.org/)).