### PR TITLE
fix team-container video LDAP auth

### DIFF
--- a/team-video/templates/deploy_jicofo.yaml
+++ b/team-video/templates/deploy_jicofo.yaml
@@ -26,6 +26,10 @@ spec:
           {{ if eq .Values.auth.type "ldap" }}
           - name: ENABLE_LDAP_AUTH
             value: "true"
+          - name: ENABLE_AUTH
+            value: "true"
+          - name: AUTH_TYPE
+            value: {{ .Values.auth.ldapjicofoauth }}
           {{else}}
           - name: ENABLE_AUTH
             value: "true"

--- a/team-video/templates/deploy_prosody.yaml
+++ b/team-video/templates/deploy_prosody.yaml
@@ -43,6 +43,54 @@ spec:
             {{end}}
           - name: AUTH_TYPE
             value: {{ .Values.auth.type }}
+            {{ if .Values.auth.ldapauthmethod}}
+          - name: LDAP_AUTH_METHOD
+            value: {{ .Values.auth.ldapauthmethod}}
+            {{end}}
+            {{ if .Values.auth.ldapurl }}
+          - name: LDAP_URL
+            value: {{ .Values.auth.ldapurl }}
+            {{end}}
+            {{ if .Values.auth.ldapusetls }}
+          - name: LDAP_USE_TLS
+            value: {{ .Values.auth.ldapusetls }}
+            {{end}}
+            {{ if .Values.auth.ldapstarttls }}
+          - name: LDAP_START_TLS
+            value: {{ .Values.auth.ldapstarttls }}
+            {{end}}
+            {{ if .Values.auth.ldaptlscacertfile }}
+          - name: LDAP_TLS_CACERT_FILE
+            value: {{ .Values.auth.ldaptlscacertfile }}
+            {{end}}
+            {{ if .Values.auth.ldaptlscacertdir }}
+          - name: LDAP_TLS_CACERT_DIR
+            value: {{ .Values.auth.ldaptlscacertdir }}
+            {{end}}
+            {{ if .Values.auth.ldapcheckpeer }}
+          - name: LDAP_TLS_CHECK_PEER
+            value: {{ .Values.auth.ldapcheckpeer }}
+            {{end}}
+            {{ if .Values.auth.ldapbase }}
+          - name: LDAP_BASE
+            value: {{ .Values.auth.ldapbase }}
+            {{end}}
+            {{ if .Values.auth.ldapbinddn }}
+          - name: LDAP_BINDDN
+            value: {{ .Values.auth.ldapbinddn }}
+            {{end}}
+            {{ if .Values.auth.ldapbindpw }}
+          - name: LDAP_BINDPW
+            value: {{ .Values.auth.ldapbindpw }}
+            {{end}}
+            {{ if .Values.auth.ldapfilter }}
+          - name: LDAP_FILTER
+            value: {{ .Values.auth.ldapfilter }}
+            {{end}}
+            {{ if .Values.auth.ldapversion }}
+          - name:  LDAP_VERSION
+            value: {{ .Values.auth.ldapversion }}
+            {{end}}
           {{end}}
           - name: XMPP_DOMAIN
             value: {{ .Values.app.name }}.{{ .Values.app.domain }}
@@ -72,3 +120,5 @@ spec:
             value: internal-muc.{{ .Values.app.name }}.{{ .Values.app.domain }}
           - name: TZ
             value: Europe/Paris
+          - name: PUBLIC_URL
+            value: "https://{{ .Values.app.name }}.{{ .Values.app.domain }}"

--- a/values-video.yaml
+++ b/values-video.yaml
@@ -25,6 +25,9 @@ auth:
   #ldapbindpw: VerySecretPassword
   #ldapfilter: (&(&(|(objectclass=person)))(|(samaccountname=%uid)(|(mailPrimaryAddress=%uid)(mail=%uid))))
   #ldapversion: 3 # can break helm upgrade
+  # jicofo needs this, if (and only if) LDAP auth is used
+  #ldapjicofoauth: XMPP
+
 
 logLevel: "info"
 hideWelcomePage: true


### PR DESCRIPTION
This fixes team-video for use with LDAP auth. Recent changes in docker-jitsi-meet require environment changes in the jicofo container, the other stuff was required since quite a while.